### PR TITLE
Navbar fix- currently invisible on live site 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -299,23 +299,38 @@ ul.social-btns li a:before {
 
 /* "navbar-scrolled" class and keyframes activated when scrolling */
 .navbar-scrolled {
-    background: rgb(35, 35, 35);
+    background: rgba(0, 0, 0, 0.3);
     -webkit-animation-name: example; /* Safari 4.0 - 8.0 */
-    -webkit-animation-duration: 0.5s; /* Safari 4.0 - 8.0 */
+    -webkit-animation-duration: 0.75s; /* Safari 4.0 - 8.0 */
     animation-name: example;
-    animation-duration: 0.5s;
+    animation-duration: 0.75s;
 }
 
+.navbar-scrolled {
+     background: rgba(0, 0, 0, 0.3);
+     -webkit-animation-name: example; /* Safari 4.0 - 8.0 */
+     -webkit-animation-duration: 0.75s; /* Safari 4.0 - 8.0 */
+     animation-name: example;
+     animation-duration: 0.75s;
+ }
+.navbar-absolute {
+     background: rgba(0, 0, 0, 0.3);
+     position: absolute;
+     top: 0;
+     right: 0;
+     left: 0;
+     z-index: 1030;
+ }
 /* Safari 4.0 - 8.0 */
 @-webkit-keyframes example {
     from {background-color: rgba(0,0,0,0);}
-    to {background-color: rgb(35, 35, 35);}
+    to {background: rgba(0, 0, 0, 0.3);}
 }
 
 /* Chrome */
 @keyframes example {
     from {background-color: rgba(0,0,0,0);}
-    to {background-color: rgb(35, 35, 35);}
+    to {background: rgba(0, 0, 0, 0.3);}
 }
 
 /* Media Queries */

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -2,15 +2,26 @@
 window.onscroll = () => {
     const nav = document.getElementById("navbar");
     let y = window.scrollY;
-    if (window.location.pathname.match(/.+clubs.html/) === false) {
-      if(y >= 150) {
-        nav.classList.add("navbar-scrolled");
-      }
-      else {
-        nav.classList.remove("navbar-scrolled");
-      }
-    }
+     if(y >= 700) {
+          nav.classList.add("navbar-scrolled");
+          
+     }
+     else if (y < 650){
+          nav.classList.remove("navbar-scrolled");
+     }
 };
+
+$(document).ready(function() {
+     var url = window.location.href;
+     var lastPart = url.substr(url.lastIndexOf('/') + 1);
+     if (lastPart === "clubs.html") {
+          const nav = document.getElementById("navbar");
+          nav.classList.remove("navbar-scrolled");
+          nav.classList.remove("top-fixed");
+          nav.classList.add("navbar-absolute");
+     }
+})
+
 
 
 // Retrieved from w3schools, makes scrolling smooth on anchor tag clicks in navbar


### PR DESCRIPTION
Currently, faulty javascript renders the navbar invisible on the homepage when scrolling down, and completely invisible on the clubs page.
These changes fix the homepage issue by applying a css class once the homepage has been scrolled down to add a semitransparent background to the navbar.
On clubs.html, the navbar is changed to a position: absolute so that it stays at the top of the page. This also lets the user see the navbar when they are on clubs.html now.

This code could be improved by changing the navbar to use a special css class only on clubs.html that has an absolute position. Currently, the code continues the logic of checking if the page is clubs.html and removes and adds the correct css selector.